### PR TITLE
fix for revival popup in specdm

### DIFF
--- a/lua/terrortown/entities/roles/occultist/shared.lua
+++ b/lua/terrortown/entities/roles/occultist/shared.lua
@@ -82,6 +82,7 @@ if SERVER then
 
 	hook.Add("TTT2PostPlayerDeath", "ttt2_role_occultist_post_player_death", function(ply)
 		if ply:GetSubRole() ~= ROLE_OCCULTIST then return end
+		if SpecDM and (ply.IsGhost and ply:IsGhost()) then return end
 
 		-- only respawn when occ respawn was not triggered this round and player crossed revival threashold
 		if ply.occ_data.was_revived or not ply.occ_data.allow_revival then return end


### PR DESCRIPTION
Tested with and without specdm installed on the newest ttt2 version.
This fixes the problem where the revival popup comes up in specdm if the occultist gets killed there. 