### PR TITLE
Fixed Role Syncing for ROLE_NONE

### DIFF
--- a/lua/terrortown/entities/roles/occultist/shared.lua
+++ b/lua/terrortown/entities/roles/occultist/shared.lua
@@ -224,7 +224,11 @@ if SERVER then
 
 		for occul in pairs(tbl) do
 			if occul:IsTerror() and occul:Alive() and occul:GetSubRole() == ROLE_OCCULTIST then
-				tbl[occul] = {ROLE_INNOCENT, TEAM_INNOCENT}
+				if ply == occul then
+					tbl[occul] = {ROLE_INNOCENT, TEAM_INNOCENT}
+				else
+					tbl[occul] = {ROLE_NONE, TEAM_NONE}
+				end
 			end
 		end
 	end)


### PR DESCRIPTION
Fixed the Occultist's role syncing for the recent change/addition of ROLE_NONE to TTT2. 

Before, on the most recent TTT2 GitHub version, if the hidden role setting was enabled, all players would see the Occultist as publicly innocent. 